### PR TITLE
refactor: 컴포넌트에 cva와 cn을 사용하여 className 선언 가독성 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "clsx": "^2.1.1",
         "next": "14.2.11",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.9.0",
@@ -12928,6 +12929,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.4.tgz",
+      "integrity": "sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ddd-web",
       "version": "0.1.0",
       "dependencies": {
+        "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "next": "14.2.11",
         "react": "^18",
@@ -6298,6 +6299,25 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "dev": true
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/clean-css": {
       "version": "5.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ddd-web",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "next": "14.2.11",
         "react": "^18",
         "react-dom": "^18"
@@ -6322,6 +6323,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "next": "14.2.11",
     "react": "^18",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "clsx": "^2.1.1",
     "next": "14.2.11",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "14.2.11",
     "react": "^18",
     "react-dom": "^18"

--- a/src/components/Accordion/index.stories.tsx
+++ b/src/components/Accordion/index.stories.tsx
@@ -19,8 +19,8 @@ const meta = {
     size: {
       control: {
         type: "select",
-        options: ["desktop", "tablet", "mobile"],
       },
+      options: ["desktop", "tablet", "mobile"],
     },
     label: {
       control: "text",

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,45 +1,87 @@
 import { useState, useRef, useEffect } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/utils/cn";
 import AddIcon from "@/components/svgs/AddIcon";
 import SubtractIcon from "@/components/svgs/SubtractIcon";
 
-interface Props {
-  size: "desktop" | "tablet" | "mobile";
+const accordionVariants = cva("w-full flex justify-between rounded-[20px]", {
+  variants: {
+    size: {
+      desktop: "px-64 py-40",
+      tablet: "px-40 py-32",
+      mobile: "p-24",
+    },
+    isOpened: {
+      true: "bg-blue-10",
+      false: "bg-white",
+    },
+  },
+});
+
+const labelVariants = cva("", {
+  variants: {
+    size: {
+      desktop: "text-body-3-medium mb-8",
+      tablet: "text-body-3-medium mb-8",
+      mobile: "text-body-4-medium mb-4",
+    },
+  },
+});
+
+const titleVariants = cva("", {
+  variants: {
+    size: {
+      desktop: "text-title-2-bold",
+      tablet: "text-title-3-bold",
+      mobile: "text-body-3-bold",
+    },
+  },
+});
+
+const descriptionVariants = cva("text-gray-70", {
+  variants: {
+    size: {
+      desktop: "mt-24 text-body-1-regular",
+      tablet: "mt-20 text-body-2-regular",
+      mobile: "mt-16 text-body-3-regular",
+    },
+  },
+});
+
+const touchAreaVariants = cva("", {
+  variants: {
+    size: {
+      desktop: "pt-14 pl-20",
+      tablet: "pt-14 pl-20",
+      mobile: "pt-12 pl-20",
+    },
+  },
+});
+
+const iconButtonVariants = cva("", {
+  variants: {
+    size: {
+      desktop: "h-40 w-40",
+      tablet: "h-40 w-40",
+      mobile: "h-24 w-24",
+    },
+  },
+});
+
+interface Props extends VariantProps<typeof accordionVariants> {
   label: string;
   title: string;
   description: React.ReactNode;
+  className?: string;
 }
 
-const sizeClassNames = {
-  desktop: {
-    accordion: "px-64 py-40",
-    contentArea: "",
-    label: "text-body-3-medium mb-8",
-    title: "text-title-2-bold",
-    description: "mt-24 text-body-1-regular",
-    touchArea: "pt-14 pl-20",
-    touchIcon: "h-40 w-40",
-  },
-  tablet: {
-    accordion: "px-40 py-32",
-    contentArea: "",
-    label: "text-body-3-medium mb-8",
-    title: "text-title-3-bold",
-    description: "mt-20 text-body-2-regular",
-    touchArea: "pt-14 pl-20",
-    touchIcon: "h-40 w-40",
-  },
-  mobile: {
-    accordion: "p-24",
-    contentArea: "",
-    label: "text-body-4-medium mb-4",
-    title: "text-body-3-bold",
-    description: "mt-16 text-body-3-regular",
-    touchArea: "pt-12 pl-20",
-    touchIcon: "h-24 w-24",
-  },
-};
-
-export default function Accordion({ size, label, title, description }: Props) {
+export default function Accordion({
+  size = "desktop",
+  label,
+  title,
+  description,
+  className,
+}: Props) {
   const [isOpened, setIsOpened] = useState(false);
   const [contentHeight, setContentHeight] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -58,27 +100,21 @@ export default function Accordion({ size, label, title, description }: Props) {
   }
 
   return (
-    <div
-      className={`${sizeClassNames[size].accordion} ${
-        isOpened ? "bg-blue-10" : "bg-white"
-      } rounded-[20px] w-full flex justify-between`}
-    >
-      <div className={`${sizeClassNames[size].contentArea}`}>
-        <p className={`${sizeClassNames[size].label}`}>{label}</p>
-        <p className={`${sizeClassNames[size].title}`}>{title}</p>
+    <div className={cn(accordionVariants({ size, isOpened }), className)}>
+      <div>
+        <p className={cn(labelVariants({ size }))}>{label}</p>
+        <p className={cn(titleVariants({ size }))}>{title}</p>
         <div
           ref={contentRef}
           style={{ height: `${contentHeight}px` }}
-          className={`overflow-hidden transition-[height] duration-300 ease-in-out`}
+          className="overflow-hidden transition-[height] duration-300 ease-in-out"
         >
-          <div className={`${sizeClassNames[size].description} text-gray-70`}>
-            {description}
-          </div>
+          <div className={cn(descriptionVariants({ size }))}>{description}</div>
         </div>
       </div>
-      <div className={`${sizeClassNames[size].touchArea}`}>
+      <div className={cn(touchAreaVariants({ size }))}>
         <button
-          className={`${sizeClassNames[size].touchIcon}`}
+          className={cn(iconButtonVariants({ size }))}
           type="button"
           onClick={toggleAccordion}
         >

--- a/src/components/IconButton/Floating.tsx
+++ b/src/components/IconButton/Floating.tsx
@@ -1,11 +1,19 @@
 import React from "react";
+import { cn } from "@/utils/cn";
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-export default function IconButton({ children, ...restProps }: Props) {
+export default function IconButton({
+  className,
+  children,
+  ...restProps
+}: Props) {
   return (
     <button
-      className={`rounded-[99px] p-16 min-h-56 min-w-56 bg-primary-normal shadow-strong`}
+      className={cn(
+        "rounded-[99px] p-16 min-h-56 min-w-56 bg-primary-normal shadow-strong",
+        className
+      )}
       {...restProps}
     >
       {children}

--- a/src/components/IconButton/Normal.tsx
+++ b/src/components/IconButton/Normal.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/utils/cn";
+
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   showBadge?: boolean;
 }
@@ -5,14 +7,17 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export default function NormalIconButton({
   children,
   showBadge = false,
+  className,
   ...restProps
 }: Props) {
   return (
     <button
-      className={`relative rounded-[99px] p-8 min-h-40 min-w-40 hover:bg-label-normal hover:bg-opacity-[.0375] focus:bg-label-normal focus:bg-opacity-[.06] active:bg-label-normal active:bg-opacity-[.09] disabled:bg-transparent ${
+      className={cn(
+        "relative rounded-[99px] p-8 min-h-40 min-w-40 hover:bg-label-normal hover:bg-opacity-[.0375] focus:bg-label-normal focus:bg-opacity-[.06] active:bg-label-normal active:bg-opacity-[.09] disabled:bg-transparent",
         showBadge &&
-        'after:content-[""] after:absolute after:top-8 after:right-8 after:w-4 after:h-4 after:rounded-[99px] after:bg-primary-normal'
-      }`}
+          'after:content-[""] after:absolute after:top-8 after:right-8 after:w-4 after:h-4 after:rounded-[99px] after:bg-primary-normal',
+        className
+      )}
       {...restProps}
     >
       {children}

--- a/src/components/IconButton/Outlined.stories.tsx
+++ b/src/components/IconButton/Outlined.stories.tsx
@@ -20,8 +20,8 @@ const meta = {
     size: {
       control: {
         type: "select",
-        options: ["normal", "small", "custom"],
       },
+      options: ["normal", "small", "custom"],
     },
     disabled: {
       control: "boolean",

--- a/src/components/IconButton/Outlined.tsx
+++ b/src/components/IconButton/Outlined.tsx
@@ -1,23 +1,31 @@
-interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  size: "normal" | "small" | "custom";
-}
+import { cn } from "@/utils/cn";
+import { cva, type VariantProps } from "class-variance-authority";
 
-const sizeClassNames = {
-  normal: "p-8 min-h-40 min-w-40",
-  small: "p-[5px] min-h-32 min-w-32",
-  custom: "p-4 min-h-28 min-w-28",
-};
+const variants = cva(
+  "rounded-[99px] border-[1px] border-solid border-line-normal hover:bg-label-normal hover:bg-opacity-[.0375] focus:bg-label-normal focus:bg-opacity-[.06] active:bg-label-normal active:bg-opacity-[.09] disabled:bg-transparent disabled:text-label-disabled",
+  {
+    variants: {
+      size: {
+        normal: "p-8 min-h-40 min-w-40",
+        small: "p-[5px] min-h-32 min-w-32",
+        custom: "p-4 min-h-28 min-w-28",
+      },
+    },
+  }
+);
+
+interface Props
+  extends VariantProps<typeof variants>,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export default function OutlinedIconButton({
   size = "custom",
+  className,
   children,
   ...restProps
 }: Props) {
   return (
-    <button
-      className={`rounded-[99px] border-[1px] border-solid border-line-normal hover:bg-label-normal hover:bg-opacity-[.0375] focus:bg-label-normal focus:bg-opacity-[.06] active:bg-label-normal active:bg-opacity-[.09] disabled:bg-transparent disabled:text-label-disabled ${sizeClassNames[size]}`}
-      {...restProps}
-    >
+    <button className={cn(variants({ size, className }))} {...restProps}>
       {children}
     </button>
   );

--- a/src/components/IconButton/Solid.tsx
+++ b/src/components/IconButton/Solid.tsx
@@ -1,24 +1,32 @@
-interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  size: "s" | "m" | "l" | "xl";
-}
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/utils/cn";
 
-const sizeClassName = {
-  s: "p-6 min-h-28 min-w-28",
-  m: "p-8 min-h-36 min-w-36",
-  l: "p-12 min-h-48 min-w-48",
-  xl: "p-16 min-h-64 min-w-64",
-};
+const variants = cva(
+  "rounded-[99px] flex justify-center items-center bg-primary-normal text-white disabled:bg-[rgb(12,14,15)]/[.12]",
+  {
+    variants: {
+      size: {
+        s: "p-6 min-h-28 min-w-28",
+        m: "p-8 min-h-36 min-w-36",
+        l: "p-12 min-h-48 min-w-48",
+        xl: "p-16 min-h-64 min-w-64",
+      },
+    },
+  }
+);
+
+interface Props
+  extends VariantProps<typeof variants>,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export default function SolidIconButton({
   size,
+  className,
   children,
   ...restProps
 }: Props) {
   return (
-    <button
-      className={`rounded-[99px] flex justify-center items-center bg-primary-normal text-white disabled:bg-[rgb(12,14,15)]/[.12] ${sizeClassName[size]}`}
-      {...restProps}
-    >
+    <button className={cn(variants({ size, className }))} {...restProps}>
       {children}
     </button>
   );

--- a/src/components/TextButton/index.stories.tsx
+++ b/src/components/TextButton/index.stories.tsx
@@ -12,8 +12,8 @@ const meta = {
     size: {
       control: {
         type: "select",
-        options: ["s", "m", "l"],
       },
+      options: ["s", "m", "l"],
     },
     disabled: {
       control: "boolean",

--- a/src/components/TextButton/index.tsx
+++ b/src/components/TextButton/index.tsx
@@ -1,30 +1,42 @@
-interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  size?: "s" | "m" | "l";
-  variant?: "fill" | "outline" | "text";
-}
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/utils/cn";
 
-const sizeClassName = {
-  s: "px-16 py-8 text-body-3-medium",
-  m: "px-28 py-12 text-body-2-medium",
-  l: "px-32 py-16 text-body-1-medium",
-};
+const variants = cva("rounded-full flex justify-center items-center", {
+  variants: {
+    size: {
+      s: "px-16 py-8 text-body-3-medium",
+      m: "px-28 py-12 text-body-2-medium",
+      l: "px-32 py-16 text-body-1-medium",
+    },
+    variant: {
+      text: "text-text-primary disabled:text-text-inactive active:bg-gray-10",
+      outline:
+        "border-[1px] border-solid border-black disabled:border-gray-20 active:bg-button-enabled active:text-white active:border-none",
+      fill: "text-white bg-button-enabled disabled:bg-blue-20",
+    },
+  },
+});
 
-const variantClassName = {
-  text: "rounded-full text-text-primary disabled:text-text-inactive active:bg-gray-10",
-  outline:
-    "rounded-full border-[1px] border-solid border-black disabled:border-gray-20 active:bg-button-enabled active:text-white active:border-none",
-  fill: "rounded-full text-white bg-button-enabled disabled:bg-blue-20",
-};
+interface Props
+  extends VariantProps<typeof variants>,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export default function TextButton({
   size = "s",
   variant = "fill",
+  className,
   children,
   ...restProps
 }: Props) {
   return (
     <button
-      className={`flex justify-center items-center ${sizeClassName[size]} ${variantClassName[variant]}`}
+      className={cn(
+        variants({
+          size,
+          variant,
+          className,
+        })
+      )}
       {...restProps}
     >
       {children}

--- a/src/components/TextInput/index.stories.tsx
+++ b/src/components/TextInput/index.stories.tsx
@@ -19,13 +19,13 @@ const meta = {
     size: {
       control: {
         type: "select",
-        options: ["s", "l"],
       },
+      options: ["s", "l"],
     },
     disabled: {
       control: "boolean",
     },
-    iserror: {
+    error: {
       control: "boolean",
     },
   },

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,49 +1,85 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/utils/cn";
 import ErrorIcon from "@/components/svgs/ErrorIcon";
 
+const inputVariants = cva(
+  "relative rounded-[99px] border-[1.5px] border-solid border-gray-30 focus:border-blue-40 disabled:border-gray-20 disabled:bg-gray-10 disabled:text-gray-30",
+  {
+    variants: {
+      size: {
+        s: "px-20 py-14 text-body-3-medium",
+        l: "px-24 py-16 text-body-1-medium",
+      },
+      error: {
+        true: "border-red-40",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      {
+        error: true,
+        size: "s",
+        className: "pr-[44px]",
+      },
+      {
+        error: true,
+        size: "l",
+        className: "pr-[48px]",
+      },
+    ],
+  }
+);
+
+const errorIconVariants = cva(["absolute", "top-[50%]", "translate-y-[-50%]"], {
+  variants: {
+    size: {
+      s: "right-20",
+      l: "right-24",
+    },
+  },
+});
+
 interface Props
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
-  size?: "s" | "l";
-  iserror?: boolean;
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    VariantProps<typeof inputVariants>,
+    VariantProps<typeof errorIconVariants> {
   errorMessage?: string;
 }
 
-const sizeClassNames = {
-  s: {
-    input: "px-20 py-14 text-body-3-medium",
-    errorIcon: "right-20",
-  },
-  l: {
-    input: "px-24 py-16 text-body-1-medium",
-    errorIcon: "right-24",
-  },
-};
-
 export default function TextInput({
   size = "s",
-  iserror,
+  error = false,
   errorMessage = "alert",
+  className,
+  disabled,
   ...restProps
 }: Props) {
-  const errorClassName = size === "s" ? "pr-[44px]" : "pr-[48px]";
   return (
     <>
       <div className="relative">
         <input
           type="text"
-          className={`relative ${
-            sizeClassNames[size].input
-          } rounded-[99px] border-[1.5px] border-solid border-gray-30 focus:border-blue-40 ${
-            iserror && `border-red-40 ${errorClassName}`
-          } ${restProps.disabled && `border-gray-20 bg-gray-10 text-gray-30`}`}
+          className={cn(
+            inputVariants({
+              size,
+              error,
+              className,
+            })
+          )}
+          disabled={disabled}
           {...restProps}
         />
-        {iserror && (
+        {error && (
           <ErrorIcon
-            className={`absolute ${sizeClassNames[size].errorIcon} top-[50%] translate-y-[-50%]`}
+            className={cn(
+              errorIconVariants({
+                size,
+              })
+            )}
           />
         )}
       </div>
-      {iserror && (
+      {error && (
         <p className="mt-4 text-red-40 text-body-3-regular">{errorMessage}</p>
       )}
     </>

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
### 작업 내용
* 조건부 className 처리 및 tailwind className를 충돌 없이 머지할 수 있도록 cn 함수를 작성했습니다.
* props의 값에 따라 서로 다른 className을 깔끔하게 사용하기 위해 class-variance-authority 패키지를 설치했습니다.
* cn과 cva를 사용함으로써 컴포넌트의 className prop도 편리하게 핸들링할 수 있게 되었습니다. 가독성 역시 좋아졌다 생각합니다:)

### 참고자료
* [The story behind Tailwind's CN function](https://tigerabrodi.blog/the-story-behind-tailwinds-cn-function)
* [Tailwind CSS 잘 활용하기 with clxs, cva, twMerge](https://dev-102.tistory.com/entry/Tailwind-CSS-%EC%9E%98-%ED%99%9C%EC%9A%A9%ED%95%98%EA%B8%B0-with-Clxs-CVA-twMerge)
