### PR TITLE
fix: tailwind merge에서 font size와 text color가 서로 충돌 시 서로 오버라이드 되는 에러 해결

### DIFF
--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,6 +1,45 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "headline-1-semibold",
+            "headline-2-semibold",
+            "headline-3-semibold",
+            "headline-4-semibold",
+            "headline-5-bold",
+            "headline-6-medium",
+            "headline-6-semibold",
+            "headline-7-medium",
+            "headline-7-semibold",
+            "title-1-medium",
+            "title-1-bold",
+            "title-2-medium",
+            "title-2-bold",
+            "title-3-regular",
+            "title-3-bold",
+            "body-1-regular",
+            "body-1-medium",
+            "body-1-bold",
+            "body-2-regular",
+            "body-2-medium",
+            "body-2-bold",
+            "body-3-regular",
+            "body-3-medium",
+            "body-3-bold",
+            "body-4-regular",
+            "body-4-medium",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 }


### PR DESCRIPTION
### 작업 내용
* TextButton 컴포넌트에서 cn 함수 각 props 별 className을 머지할 때, text color와 font size 클래스명이 모두 `text-`prefix를 가지고 있어 하나의 클래스로 오버라이드되는 문제가 발생했습니다.
```js
onst variants = cva("rounded-full flex justify-center items-center", {
  variants: {
    size: {
      s: "text-body-3-medium",
      // ...
    },
    variant: {
      // ...
      fill: "text-white",
    },
  },
});
```
```rsx
<button
    className={cn(
      variants({
        size,
        variant, // text-white로 오버라이드 됨
        className, 
      })
    )}
    {...restProps}
>
  {children}
</button>
```
* 위의 문제는 tailwind merge 패키지에서 해당 클래스명을 오버라이드할지, 아니면 확장할지에 대한 설정을 추가해 주는 것으로 해결할 수 있습니다.
* font-size에 해당되는 클래스명들을 text color가 아닌 font-size로 인식하여 text color와 오버라이드되는 것을 방지하도록, 커스텀한 twMerge 함수를 만들어 사용합니다.

### 참고자료
* [stack overlfow](https://stackoverflow.com/questions/76355485/tailwind-merge-not-able-to-combine-color-and-typography-classes)
* [tailwind-merge docs](https://github.com/dcastil/tailwind-merge/blob/v2.3.0/docs/recipes.md#adding-custom-scale-from-tailwind-config-to-tailwind-merge-config)

### 참고사항
* 추가적으로 이러한 문제가 또 발생할 수 있을 거란 생각이 듭니다. 지금 custom theme이 좀 많아 예상할 수는 없을 거 같고 에러 발생 시 수정하는 방향으로 가면 어떨까 싶어요

### 이미지 및 동영상

- 같은 s size의 text button인데, variant fill의 'text-white'에 size s의 'text-body-3-medium'이 오버라이드되어 폰트 사이즈가 서로 다릅니다

![image](https://github.com/user-attachments/assets/7ad0bd8d-b7b2-4e2a-a232-98d6f62c3fc0)
