### PR TITLE
refactor&feat: svgr 타입스크립트 적용 및 사용법 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ SVG 파일을 관리 및 사용의 용이성을 위해 `@svgr/cli`를 사용하�
 - `src/components/svgs` 디렉토리 하위에 추가되도록 합니다.
 
 ```bash
-npx @svgr/cli -- ./src/assets/icons/{inputFileName}.svg > ./src/components/svgs/{outputFileName}.tsx
+npm run svgr
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "svgr": "npx @svgr/cli --typescript --ignore-existing --out-dir ./src/components/svgs ./src/assets/icons"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.0",

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,8 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
-import AddIcon from "@/components/svgs/AddIcon";
-import SubtractIcon from "@/components/svgs/SubtractIcon";
+import { AddIcon, SubtractIcon } from "@/components/svgs";
 
 const accordionVariants = cva("w-full rounded-[20px]", {
   variants: {

--- a/src/components/IconButton/Floating.stories.tsx
+++ b/src/components/IconButton/Floating.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import FloatingIconButton from "./Floating";
-import AddIcon from "@/components/svgs/AddIcon";
+import { AddIcon } from "@/components/svgs";
 
 const meta = {
   title: "FloatingIconButton",

--- a/src/components/IconButton/Normal.stories.tsx
+++ b/src/components/IconButton/Normal.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import NormalIconButton from "./Normal";
-import AddIcon from "@/components/svgs/AddIcon";
+import { AddIcon } from "@/components/svgs";
 
 const meta = {
   title: "NormalIconButton",

--- a/src/components/IconButton/Outlined.stories.tsx
+++ b/src/components/IconButton/Outlined.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import OutlinedIconButton from "./Outlined";
-import AddIcon from "@/components/svgs/AddIcon";
+import { AddIcon } from "@/components/svgs";
 
 const meta = {
   title: "OutlinedIconButton",

--- a/src/components/IconButton/Solid.stories.tsx
+++ b/src/components/IconButton/Solid.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import SolidIconButton from "./Solid";
-import AddIcon from "@/components/svgs/AddIcon";
+import { AddIcon } from "@/components/svgs";
 
 const meta = {
   title: "SolidIconButton",

--- a/src/components/Navigation/DesktopNavigation.tsx
+++ b/src/components/Navigation/DesktopNavigation.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import TextButton from "@/components/TextButton";
-import SvgDddIcon from "@/components/svgs/DddIcon";
+import { DddIcon } from "@/components/svgs";
 import navigationList from "@/fixtures/navigationList.json";
 
 export default function DesktopNavigation() {
@@ -10,7 +10,7 @@ export default function DesktopNavigation() {
   return (
     <div className="flex w-full justify-center pt-32">
       <div className="bg-black w-[55px] h-[55px] rounded-full flex justify-center items-center flex-shrink-0">
-        <SvgDddIcon />
+        <DddIcon />
       </div>
       <nav className="bg-white p-4 rounded-full flex gap-[2px]">
         {navigationList.map((item) => (

--- a/src/components/Navigation/MobileNavigation.tsx
+++ b/src/components/Navigation/MobileNavigation.tsx
@@ -6,6 +6,14 @@ import SvgCloseIcon from "@/components/svgs/CloseIcon";
 import SvgInstagramIcon from "@/components/svgs/InstagramIcon";
 import SvgLinkedInIcon from "@/components/svgs/LinkedInIcon";
 import SvgGithubIcon from "@/components/svgs/GithubIcon";
+import {
+  DddIcon,
+  MenuIcon,
+  CloseIcon,
+  InstagramIcon,
+  LinkedInIcon,
+  GithubIcon,
+} from "@/components/svgs";
 import navigationList from "@/fixtures/navigationList.json";
 
 const snsList = [

--- a/src/components/Navigation/MobileNavigation.tsx
+++ b/src/components/Navigation/MobileNavigation.tsx
@@ -1,11 +1,5 @@
 import Link from "next/link";
 import { useState } from "react";
-import SvgDddIcon from "@/components/svgs/DddIcon";
-import SvgMenuIcon from "@/components/svgs/MenuIcon";
-import SvgCloseIcon from "@/components/svgs/CloseIcon";
-import SvgInstagramIcon from "@/components/svgs/InstagramIcon";
-import SvgLinkedInIcon from "@/components/svgs/LinkedInIcon";
-import SvgGithubIcon from "@/components/svgs/GithubIcon";
 import {
   DddIcon,
   MenuIcon,
@@ -19,17 +13,17 @@ import navigationList from "@/fixtures/navigationList.json";
 const snsList = [
   {
     name: "Instagram",
-    icon: <SvgInstagramIcon />,
+    icon: <InstagramIcon />,
     link: "https://www.instagram.com/dynamic_ddd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
   },
   {
     name: "LinkedIn",
-    icon: <SvgLinkedInIcon />,
+    icon: <LinkedInIcon />,
     link: "https://www.linkedin.com/company/dddcommunity",
   },
   {
     name: "Github",
-    icon: <SvgGithubIcon />,
+    icon: <GithubIcon />,
     link: "https://github.com/DDD-Community",
   },
 ];
@@ -51,13 +45,13 @@ export default function MobileNavigation() {
   return (
     <div className="flex justify-between px-24 pt-24 w-full">
       <div className="bg-black w-48 h-48 rounded-full flex justify-center items-center flex-shrink-0">
-        <SvgDddIcon />
+        <DddIcon />
       </div>
       <button
         className="bg-white w-48 h-48 rounded-full flex justify-center items-center flex-shrink-0"
         onClick={openMenu}
       >
-        <SvgMenuIcon />
+        <MenuIcon />
       </button>
       {isMenuOpened && (
         <div className="px-24 fixed top-0 left-0 w-full h-[100vh] bg-blue-40 text-white flex flex-col">
@@ -66,7 +60,7 @@ export default function MobileNavigation() {
               className="bg-white w-48 h-48 rounded-full flex justify-center items-center flex-shrink-0"
               onClick={closeMenu}
             >
-              <SvgCloseIcon />
+              <CloseIcon />
             </button>
           </header>
           <main className="flex flex-col justify-center flex-1">

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
-import ErrorIcon from "@/components/svgs/ErrorIcon";
+import { ErrorIcon } from "@/components/svgs";
 
 const inputVariants = cva(
   "relative rounded-[99px] border-[1.5px] border-solid border-gray-30 focus:border-blue-40 disabled:border-gray-20 disabled:bg-gray-10 disabled:text-gray-30",

--- a/src/components/svgs/AddIcon.tsx
+++ b/src/components/svgs/AddIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgAddIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgAddIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/src/components/svgs/CloseIcon.tsx
+++ b/src/components/svgs/CloseIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgCloseIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgCloseIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}
@@ -21,4 +22,3 @@ const SvgCloseIcon = (props) => (
   </svg>
 );
 export default SvgCloseIcon;
-

--- a/src/components/svgs/DddIcon.tsx
+++ b/src/components/svgs/DddIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgDddIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgDddIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={23}

--- a/src/components/svgs/ErrorIcon.tsx
+++ b/src/components/svgs/ErrorIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgErrorIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgErrorIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}

--- a/src/components/svgs/GithubIcon.tsx
+++ b/src/components/svgs/GithubIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgGithubIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgGithubIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}
@@ -14,4 +15,3 @@ const SvgGithubIcon = (props) => (
   </svg>
 );
 export default SvgGithubIcon;
-

--- a/src/components/svgs/InstagramIcon.tsx
+++ b/src/components/svgs/InstagramIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgInstagramIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgInstagramIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}
@@ -14,4 +15,3 @@ const SvgInstagramIcon = (props) => (
   </svg>
 );
 export default SvgInstagramIcon;
-

--- a/src/components/svgs/LinkedInIcon.tsx
+++ b/src/components/svgs/LinkedInIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgLinkedInIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgLinkedInIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}
@@ -14,4 +15,3 @@ const SvgLinkedInIcon = (props) => (
   </svg>
 );
 export default SvgLinkedInIcon;
-

--- a/src/components/svgs/MenuIcon.tsx
+++ b/src/components/svgs/MenuIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgMenuIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgMenuIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}
@@ -11,4 +12,3 @@ const SvgMenuIcon = (props) => (
   </svg>
 );
 export default SvgMenuIcon;
-

--- a/src/components/svgs/SubtractIcon.tsx
+++ b/src/components/svgs/SubtractIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-const SvgSubtractIcon = (props) => (
+import type { SVGProps } from "react";
+const SvgSubtractIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/src/components/svgs/index.ts
+++ b/src/components/svgs/index.ts
@@ -1,0 +1,9 @@
+export { default as AddIcon } from "./AddIcon";
+export { default as CloseIcon } from "./CloseIcon";
+export { default as DddIcon } from "./DddIcon";
+export { default as ErrorIcon } from "./ErrorIcon";
+export { default as GithubIcon } from "./GithubIcon";
+export { default as InstagramIcon } from "./InstagramIcon";
+export { default as LinkedInIcon } from "./LinkedInIcon";
+export { default as MenuIcon } from "./MenuIcon";
+export { default as SubtractIcon } from "./SubtractIcon";


### PR DESCRIPTION
### 작업 내용
* 빌드 시 svgr로 제작한 svg 컴포넌트에서 타입스크립트 에러가 발생해 이를 해결하는 과정에서, package.json에 svgr/cli 관련 스크립트를 만들어 사용성을 높였습니다.
  * 기존: svg 파일의 이름과 생성하고자 하는 컴포넌트 이름을 각각 적어주어야 함
  * 개선: `npm run svgr` 스크립트 실행 시 생성되지 않은 svg 컴포넌트 일괄 생성
* script 내 적용한 cli 옵션
  * `--typescript`: 타입스크립트 적용
  * `--ignore-existing`: 이미 생성된 컴포넌트의 경우 건너뛰기
  * `--out-dir <dist 폴더>`: 해당 폴더에 있는 모든 svg 파일들에 대해 컴포넌트 생성
* svgr로 생성한 svg 컴포넌트 디렉토리에 index.ts가 생성되어 여러 컴포넌트 import 시 중복 코드를 줄였습니다.
