### PR TITLE
fix: useMediaQuery로 인한 컴포넌트 렌더링 오류 해결

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -35,7 +35,7 @@ export default function FAQ() {
     if (isTablet) return "tablet";
     return "desktop";
   }, [isMobile, isTablet]);
-  
+
   const [accordionSize, setAccordionSize] = useState<AccordionSize>(
     getDeviceType()
   );
@@ -43,6 +43,8 @@ export default function FAQ() {
   useEffect(() => {
     setAccordionSize(getDeviceType());
   }, [isDesktop, isTablet, getDeviceType]);
+
+  if (isMobile === null || isTablet === null || isDesktop === null) return null;
 
   return (
     <div className="flex flex-col items-center netbook:px-0">

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -42,7 +42,7 @@ export default function FAQ() {
 
   useEffect(() => {
     setAccordionSize(getDeviceType());
-  }, [isDesktop, isTablet, getDeviceType]);
+  }, [isMobile, isDesktop, isTablet, getDeviceType]);
 
   if (isMobile === null || isTablet === null || isDesktop === null) return null;
 

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import TextButton from "@/components/TextButton";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import faqList from "@/app/faq/faqList";
@@ -30,19 +30,19 @@ export default function FAQ() {
   const isTablet = useMediaQuery(screenMediaQuery.netbook);
   const isDesktop = useMediaQuery(screenMediaQuery.desktop);
 
-  function getDeviceType(): AccordionSize {
+  const getDeviceType = useCallback(() => {
     if (isMobile) return "mobile";
     if (isTablet) return "tablet";
     return "desktop";
-  }
-
+  }, [isMobile, isTablet]);
+  
   const [accordionSize, setAccordionSize] = useState<AccordionSize>(
     getDeviceType()
   );
 
   useEffect(() => {
     setAccordionSize(getDeviceType());
-  }, [isDesktop, isTablet]);
+  }, [isDesktop, isTablet, getDeviceType]);
 
   return (
     <div className="flex flex-col items-center netbook:px-0">

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -7,6 +7,10 @@ import { screenMediaQuery } from "@/app/styles/screens";
 export default function Navigation() {
   const isDesktop = useMediaQuery(screenMediaQuery.desktop);
 
+  if (isDesktop === null) {
+    return null;
+  }
+
   if (isDesktop) {
     return <DesktopNavigation />;
   }

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,7 +1,28 @@
 import { useEffect, useState } from "react";
 
+/**
+ * 현재 화면 너비가 인자로 받은 media query string을 만족하는지 여부를 판단하는 커스텀 훅
+ * @param {string} query - media query string, ex. "(max-width: 768px)"
+ * @returns {boolean | null} 컴포넌트가 마운트되기 전에는 null, 마운트된 후에는 화면 너비가 query 조건에 부합하는지 여부
+ * @example
+ * ```
+ * export default function Example() {
+ *  const isDesktop = useMediaQuery("(min-width: 768px)");
+ *    // 컴포넌트 마운트되기 전
+ *    if (isDesktop === null) {
+ *      return null;
+ *    }
+ *  
+ *    if (isDesktop) {
+ *      return <Desktop />;
+ *    }
+ *  
+ *    return <Mobile />;
+ *  }
+ * ```
+ */
 export default function useMediaQuery(query: string) {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState<boolean | null>(null);
 
   function handleChange(e: MediaQueryListEvent) {
     setMatches(e.matches);


### PR DESCRIPTION
### 작업 내용
* useMediaQuery에서 `matches` 상태의 초기값이 false로 설정되어 있어, 해당 훅을 사용하는 컴포넌트가 마운트되기 전에 초기값으로 화면이 잠깐 보였다 원상복구되는 현상이 있습니다.
  * a. 데스크톱에서 새로고침 시 모바일 네비게이션이 나오다 데스크톱 네비게이션으로 원복되는 현상
  * b. 새로고침 시 화면 사이즈에 해당하지 않는 컴포넌트 크기(ex. 데스크톱 화면에서 새로고침 시 버튼과 아코디언이 사이즈 S에서 L로 바뀜)가 나오다 원복되는 현상
* 초기값을 null로 설정하고 이 훅을 사용하는 컴포넌트에서 `matches`의 값이 null이면 렌더링되지 않도록 조치했습니다. 
* 마운트되기 전까지는 화면에서 보이지 않다가 마운트 이후에 제대로 `matches`의 값이 계산되어 적용됩니다.

### 이미지 혹은 동영상
[상황 a, b]

https://github.com/user-attachments/assets/14e6040e-fef2-46e3-bfcf-b85e0c9abf19

