### PR TITLE
feat: 여러 개의 Accordion 컴포넌트가 있을 때 오직 하나만 열리도록 AccordionGroup을 추가

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import TextButton from "@/components/TextButton";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import faqList from "@/app/faq/faqList";
-import Accordion from "@/components/Accordion";
+import { Accordion, AccordionGroup } from "@/components/Accordion";
 import { screenMediaQuery } from "@/app/styles/screens";
 
 type QuestionType = "recruitment" | "operation" | "activities";
@@ -67,16 +67,8 @@ export default function FAQ() {
             </TextButton>
           ))}
         </div>
-        <div className="pt-48 pb-[200px] flex flex-col gap-16">
-          {faqList[questionType].map((item) => (
-            <Accordion
-              key={item.title}
-              label={item.label}
-              title={item.title}
-              description={item.description}
-              size={accordionSize}
-            />
-          ))}
+        <div className="pt-48 pb-[200px]">
+          <AccordionGroup list={faqList[questionType]} size={accordionSize} />
         </div>
       </main>
     </div>

--- a/src/components/Accordion/index.stories.tsx
+++ b/src/components/Accordion/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useArgs } from "@storybook/preview-api";
 
-import Accordion from "./index";
+import { Accordion } from "./index";
 
 const meta = {
   title: "Accordion",
@@ -31,6 +32,7 @@ const meta = {
     description: {
       control: "text",
     },
+    onClick: () => {},
   },
 } satisfies Meta<typeof Accordion>;
 
@@ -56,6 +58,16 @@ export const Desktop: Story = {
         진행할 분들에게 따로 연락을 드려요.
       </p>
     ),
+    isActive: false,
+    onClick: () => {},
+  },
+  render: function Render(args) {
+    const [{ isActive }, updateArgs] = useArgs();
+    function onClick() {
+      updateArgs({ isActive: !isActive });
+    }
+
+    return <Accordion {...args} onClick={onClick} />;
   },
 };
 
@@ -78,6 +90,16 @@ export const Tablet: Story = {
         진행할 분들에게 따로 연락을 드려요.
       </p>
     ),
+    isActive: false,
+    onClick: () => {},
+  },
+  render: function Render(args) {
+    const [{ isActive }, updateArgs] = useArgs();
+    function onClick() {
+      updateArgs({ isActive: !isActive });
+    }
+
+    return <Accordion {...args} onClick={onClick} />;
   },
 };
 
@@ -100,5 +122,15 @@ export const Mobile: Story = {
         진행할 분들에게 따로 연락을 드려요.
       </p>
     ),
+    isActive: false,
+    onClick: () => {},
+  },
+  render: function Render(args) {
+    const [{ isActive }, updateArgs] = useArgs();
+    function onClick() {
+      updateArgs({ isActive: !isActive });
+    }
+
+    return <Accordion {...args} onClick={onClick} />;
   },
 };

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, PropsWithChildren } from "react";
+import { useState, useRef, useEffect } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 import { AddIcon, SubtractIcon } from "@/components/svgs";

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,4 +1,6 @@
-import { useState, useRef, useEffect } from "react";
+"use client";
+
+import { useState, useRef, useEffect, PropsWithChildren } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 import { AddIcon, SubtractIcon } from "@/components/svgs";
@@ -63,36 +65,35 @@ const iconButtonVariants = cva("", {
   },
 });
 
-interface Props extends VariantProps<typeof accordionVariants> {
+interface AccordionProps extends VariantProps<typeof accordionVariants> {
   label: string;
   title: string;
   description: React.ReactNode;
   className?: string;
+  isActive: boolean;
+  onClick: () => void;
 }
 
-export default function Accordion({
+export function Accordion({
   size = "desktop",
   label,
   title,
   description,
   className,
-}: Props) {
-  const [isOpened, setIsOpened] = useState(false);
+  isActive,
+  onClick,
+}: AccordionProps) {
   const [contentHeight, setContentHeight] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const contentEl = contentRef.current;
-    if (isOpened && contentEl) {
+    if (isActive && contentEl) {
       setContentHeight(contentEl.scrollHeight);
     } else {
       setContentHeight(0);
     }
-  }, [isOpened]);
-
-  function toggleAccordion() {
-    setIsOpened(!isOpened);
-  }
+  }, [isActive]);
 
   return (
     <div className={cn(accordionVariants({ size }), className)}>
@@ -105,9 +106,9 @@ export default function Accordion({
           <button
             className={cn(iconButtonVariants({ size }))}
             type="button"
-            onClick={toggleAccordion}
+            onClick={onClick}
           >
-            {isOpened ? <SubtractIcon /> : <AddIcon />}
+            {isActive ? <SubtractIcon /> : <AddIcon />}
           </button>
         </div>
       </div>
@@ -118,6 +119,35 @@ export default function Accordion({
       >
         <div className={cn(descriptionVariants({ size }))}>{description}</div>
       </div>
+    </div>
+  );
+}
+
+interface AccordionGroupProps {
+  list: Array<{ label: string; title: string; description: React.ReactNode }>;
+  size: AccordionProps["size"];
+}
+
+export function AccordionGroup({ list, size = "tablet" }: AccordionGroupProps) {
+  const [activeItemIndex, setActiveItemIndex] = useState<number | null>(null);
+
+  const handleItemClick = (key: number) => {
+    setActiveItemIndex((prev) => (prev === key ? null : key));
+  };
+
+  return (
+    <div className="flex flex-col gap-16">
+      {list.map((item, index) => (
+        <Accordion
+          key={item.title}
+          label={item.label}
+          title={item.title}
+          description={item.description}
+          size={size}
+          isActive={activeItemIndex === index}
+          onClick={() => handleItemClick(index)}
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용
* 여러 개의 아코디언 컴포넌트가 있을 때 오직 하나의 아코디언만 열려 있도록 동작을 수정합니다. 이를 위해 AccordionGroup 컴포넌트를 만들었습니다.
* 아코디언 컴포넌트를 열고 닫는 로직이 내부 state에서 onClick prop으로 변경되면서, 스토리북에서 아코디언 버튼 클릭 시 열고 닫는 액션을 추가해주기 위해 [useArgs](https://storybook.js.org/docs/writing-stories/args#setting-args-from-within-a-story)를 사용합니다.

### 이미지 혹은 동영상

https://github.com/user-attachments/assets/cfe5ae0a-555e-4a2f-94b7-b70ae34a98bf

