### PR TITLE
fix: 시스템에서 다크 모드 설정 시 텍스트 색상이 다르게 나오는 문제 해결

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,8 +9,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #ffffff;
+    --foreground: #171717;
   }
 }
 


### PR DESCRIPTION
### 작업 내용
* 시스템에서 다크 모드 설정되어 있을 시 FAQ의 텍스트 색상이 디자인과 다르게 나오는 문제를 해결합니다(macOS Safari&Chrome, iOS Safari, Android Chrome).
* tailwind 전역 css 설정에서 prefers-color-scheme을 적용하고 있었습니다.
* 지금은 라이트 모드와 다크 모드일 때 body의 color와 background color를 같은 색상으로 설정했지만, 추후 다크 모드 적용하면 다시 봐야 할 것 같아 지워버리지는 않았습니다.

### 참고사항
* 안드로이드 삼성 인터넷은 브라우저 자체 다크 모드 테마가 prefers-color-scheme을 덮어씌우는 현상이 있네요. 그래서 제 핸드폰에서는 제대로(?) 나왔던 거 같습니다🤣

### 이미지 혹은 동영상
[현상]
<img src="https://github.com/user-attachments/assets/a935b44b-ec0f-4a99-b74a-6c7818141dc2" width="300px" />

[안드로이드 삼성 인터넷]
<img width="300" alt="image1" src="https://github.com/user-attachments/assets/cd02e3aa-f562-48cd-a668-4f4b756cf96f" />
