### PR TITLE
fix: outline TextButton의 경우 border의 값이 높이와 너비에 포함이 되어 다른 버튼들보다 2px씩 큰 문제 해결

### DIFF
--- a/src/app/styles/spacing.ts
+++ b/src/app/styles/spacing.ts
@@ -4,6 +4,7 @@ const spacing: CustomThemeConfig["spacing"] = {
   "4": "4px",
   "6": "6px",
   "8": "8px",
+  "10": "10px",
   "12": "12px",
   "14": "14px",
   "16": "16px",

--- a/src/components/TextButton/index.tsx
+++ b/src/components/TextButton/index.tsx
@@ -15,6 +15,23 @@ const variants = cva("rounded-full flex justify-center items-center w-fit", {
       fill: "text-white bg-button-enabled disabled:bg-blue-20",
     },
   },
+  compoundVariants: [
+    {
+      size: "s",
+      variant: "outline",
+      className: "px-[15px] py-[7px]",
+    },
+    {
+      size: "m",
+      variant: "outline",
+      className: "px-[27px] py-[11px]",
+    },
+    {
+      size: "l",
+      variant: "outline",
+      className: "px-[31px] py-[15px]",
+    },
+  ],
 });
 
 interface Props


### PR DESCRIPTION
### 작업 내용
* 버튼들의 높이와 너비를 통일하기 위해 outline 버튼의 경우 패딩 값을 다른 버튼들에 비해 1px씩 낮춥니다.

