### PR TITLE
feat: 메인 페이지에서 사용되는 각 섹션 컨테이너 컴포넌트화

### DIFF
--- a/src/app/_components/SectionContainer.tsx
+++ b/src/app/_components/SectionContainer.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/utils/cn";
+
+interface Props {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function SectionContainer({ className, children }: Props) {
+  return (
+    <section
+      className={cn("desktop:px-0 netbook:px-80 tablet:px-32 px-24", className)}
+    >
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
### 작업 내용
* 메인 페이지의 각 섹션들의 가로 패딩 크기가 모두 동일하여 공통화를 위해 컴포넌트화 합니다. className을 prop으로 받아 추가적인 스타일을 넘겨줄 수 있습니다.

### 사용법
```ts
<SectionContainer className="w-full text-center py-[240px] bg-bg-default">
      <h2 className="text-text-primary text-title-s">About Us</h2>
</SectionContainer>
```