### PR TITLE
fix: 메인 페이지 섹션에서 중복되는 className 머지하지 않도록 수정

### DIFF
--- a/src/app/_components/SectionContainer.tsx
+++ b/src/app/_components/SectionContainer.tsx
@@ -8,7 +8,7 @@ interface Props {
 export default function SectionContainer({ className, children }: Props) {
   return (
     <section
-      className={cn("desktop:px-0 netbook:px-80 tablet:px-32 px-24", className)}
+      className={`desktop:px-0 netbook:px-80 tablet:px-32 px-24 ${className}`}
     >
       {children}
     </section>


### PR DESCRIPTION
### 작업 내용
* SectionContainer의 className prop을 루트 요소의 className 속성으로 넣어줄 때, `cn` 함수를 사용하면 background 관련 class들이 잘못 오버라이드되는 문제가 있습니다. 둘 다 prefix가 `bg`로 시작해서 생기는 문제로 보입니다.
* 애초에 `cn` 함수는 variants에 따라 달라지는 className + prop으로 내려주는 className 둘을 합칠 때 서로의 충돌을 막기 위해 사용하는데, `SectionContainer`에서는 유연하게 사용할 수 있도록 일단 cn 함수 제외하겠습니다.

```
// 예시
<SectionContainer className="bg-white bg-[url('/imgs/about-us.webp')] bg-no-repeat bg-[length:330px_415px] bg-[center_455px]">

// 다음과 같이 적용됨
<section className="bg-no-repeat bg-[length:330px_415px] bg-[center_455px]">
```