### PR TITLE
refactor: warning 해결 및 불필요한 코드 수정

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import TextButton from "@/components/TextButton";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import faqList from "@/app/faq/faqList";
@@ -30,21 +30,19 @@ export default function FAQ() {
   const isTablet = useMediaQuery(screenMediaQuery.netbook);
   const isDesktop = useMediaQuery(screenMediaQuery.desktop);
 
-  const getDeviceType = useCallback(() => {
+  const deviceType = useMemo(() => {
     if (isMobile) return "mobile";
     if (isTablet) return "tablet";
     return "desktop";
-  }, [isMobile, isTablet]);
+  }, [isMobile, isTablet, isDesktop]);
 
-  const [accordionSize, setAccordionSize] = useState<AccordionSize>(
-    getDeviceType()
-  );
+  const [accordionSize, setAccordionSize] = useState<AccordionSize>(deviceType);
 
   useEffect(() => {
-    setAccordionSize(getDeviceType());
-  }, [isMobile, isDesktop, isTablet, getDeviceType]);
+    setAccordionSize(deviceType);
+  }, [deviceType]);
 
-  if (isMobile === null || isTablet === null || isDesktop === null) return null;
+  if ([isMobile, isTablet, isDesktop].some((val) => val == null)) return null;
 
   return (
     <div className="flex flex-col items-center netbook:px-0">

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -58,11 +58,10 @@ export default function Footer() {
           <LinkList label="Follow Us">
             <ul className="flex flex-wrap items-center mobile:flex-col mobile:gap-16">
               {snsList.map((item, index) => (
-                <>
+                <div className="flex items-center" key={item.name}>
                   <Link
                     className="flex items-center gap-4 text-title-1-bold mobile:text-title-2-bold"
                     href={item.link}
-                    key={item.name}
                     target="_blank"
                   >
                     {item.icon}
@@ -71,7 +70,7 @@ export default function Footer() {
                   {index < snsList.length - 1 && (
                     <span className="mx-16 w-[1px] h-[14px] bg-blue-20 mobile:hidden" />
                   )}
-                </>
+                </div>
               ))}
             </ul>
           </LinkList>

--- a/src/components/TextButton/index.tsx
+++ b/src/components/TextButton/index.tsx
@@ -11,27 +11,10 @@ const variants = cva("rounded-full flex justify-center items-center w-fit", {
     variant: {
       text: "text-text-primary disabled:text-text-inactive active:bg-gray-10",
       outline:
-        "border-[1px] border-solid border-black disabled:border-gray-20 active:bg-button-enabled active:text-white active:border-none",
-      fill: "text-white bg-button-enabled disabled:bg-blue-20",
+        "border-[1px] border-solid border-black disabled:border-gray-20 active:bg-button-enabled active:text-white active:border-button-enabled",
+      fill: "text-white border-[1px] border-solid border-button-enabled bg-button-enabled disabled:bg-blue-20 disabled:border-blue-20",
     },
   },
-  compoundVariants: [
-    {
-      size: "s",
-      variant: "outline",
-      className: "px-[15px] py-[7px]",
-    },
-    {
-      size: "m",
-      variant: "outline",
-      className: "px-[27px] py-[11px]",
-    },
-    {
-      size: "l",
-      variant: "outline",
-      className: "px-[31px] py-[15px]",
-    },
-  ],
 });
 
 interface Props

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,39 +1,15 @@
 import { clsx, type ClassValue } from "clsx";
 import { extendTailwindMerge } from "tailwind-merge";
+import fontSize from "@/app/styles/typography";
+
+const fontSizeThemes = Object.keys(fontSize)
 
 const customTwMerge = extendTailwindMerge({
   extend: {
     classGroups: {
       "font-size": [
         {
-          text: [
-            "headline-1-semibold",
-            "headline-2-semibold",
-            "headline-3-semibold",
-            "headline-4-semibold",
-            "headline-5-bold",
-            "headline-6-medium",
-            "headline-6-semibold",
-            "headline-7-medium",
-            "headline-7-semibold",
-            "title-1-medium",
-            "title-1-bold",
-            "title-2-medium",
-            "title-2-bold",
-            "title-3-regular",
-            "title-3-bold",
-            "body-1-regular",
-            "body-1-medium",
-            "body-1-bold",
-            "body-2-regular",
-            "body-2-medium",
-            "body-2-bold",
-            "body-3-regular",
-            "body-3-medium",
-            "body-3-bold",
-            "body-4-regular",
-            "body-4-medium",
-          ],
+          text: fontSizeThemes,
         },
       ],
     },


### PR DESCRIPTION
### 작업 내용
* [불필요한 아코디언 사이즈 판별 코드 줄이기](https://github.com/dddstudy/ddd-web/commit/69f2555e31b46c3b8d084f5eb7793e14cb4160db)
  * screen 관련한 상태의 변경사항 아니면 다시 계산하지 않아도 되므로 useMemo 사용
* [TextButton outline과 fill 버튼이 서로 크기가 달라, 변경할 때 레이아웃이 흔들리는 문제 해결](https://github.com/dddstudy/ddd-web/pull/34/commits/e41b3cb04d75a125ff2816ebbf51fb113002ee10)
  * fill의 백그라운드와 같은 색의 border를 outline과 똑같이 적용하는 것으로 해결하였습니다.
