### PR TITLE
feat: 모바일 네비게이션과 사이드 메뉴 분리 및 이슈 해결

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { InstagramIcon, LinkedInIcon, GithubIcon } from "@/components/svgs";
+import snsList from "@/components/common/snsList";
 
 function LinkList({
   label,
@@ -25,24 +25,6 @@ function HeaderTitle({ title }: { title: string }) {
 }
 
 export default function Footer() {
-  const snsList = [
-    {
-      name: "Instagram",
-      icon: <InstagramIcon />,
-      link: "https://www.instagram.com/dynamic_ddd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
-    },
-    {
-      name: "LinkedIn",
-      icon: <LinkedInIcon />,
-      link: "https://www.linkedin.com/company/dddcommunity",
-    },
-    {
-      name: "Github",
-      icon: <GithubIcon />,
-      link: "https://github.com/DDD-Community",
-    },
-  ];
-
   return (
     <footer className="bg-blue-50 text-white py-80 tablet:py-64 mobile:py-52 flex flex-col justify-between items-center overflow-hidden">
       <section className="desktop:mb-[289px] netbook:mb-[200px] tablet:mb-[120px] mb-[88px]">

--- a/src/components/Navigation/DesktopNavigation.tsx
+++ b/src/components/Navigation/DesktopNavigation.tsx
@@ -21,7 +21,7 @@ export default function DesktopNavigation() {
       <div className="bg-black w-[55px] h-[55px] rounded-full flex justify-center items-center flex-shrink-0">
         <DddIcon />
       </div>
-      <nav className="bg-white bg-opacity-[.84] p-4 rounded-full flex gap-[2px] backdrop-blur-[2.5px]">
+      <nav className="bg-white bg-opacity-[.84] p-4 rounded-full flex gap-[2px] after:backdrop-blur-[2.5px]">
         {navigationList.map((item) => (
           <Link className="flex-shrink-0" href={item.href} key={item.name}>
             <TextButton

--- a/src/components/Navigation/MobileNavigation.tsx
+++ b/src/components/Navigation/MobileNavigation.tsx
@@ -1,8 +1,6 @@
-import Link from "next/link";
 import { useEffect, useState } from "react";
-import { DddIcon, MenuIcon, CloseIcon } from "@/components/svgs";
-import snsList from "@/components/common/snsList";
-import navigationList from "@/fixtures/navigationList.json";
+import { DddIcon, MenuIcon } from "@/components/svgs";
+import SideMenu from "./SideMenu";
 
 export default function MobileNavigation() {
   const [isMenuOpened, setMenuOpened] = useState(false);
@@ -34,60 +32,7 @@ export default function MobileNavigation() {
       >
         <MenuIcon />
       </button>
-      {isMenuOpened && (
-        <div className="px-24 fixed top-0 left-0 w-full h-[100dvh] bg-blue-40 text-white flex flex-col">
-          <header className="pt-24 flex justify-end">
-            <button
-              className="bg-white w-48 h-48 rounded-full flex justify-center items-center flex-shrink-0"
-              onClick={closeMenu}
-            >
-              <CloseIcon />
-            </button>
-          </header>
-          <main className="flex flex-col justify-center flex-1">
-            <div className="flex flex-col gap-6 tablet:gap-20">
-              {navigationList.map((item) => (
-                <Link
-                  href={item.href}
-                  key={item.name}
-                  className="text-headline-5-bold font-medium tablet:text-headline-4-semibold tablet:font-medium"
-                >
-                  {item.name}
-                </Link>
-              ))}
-            </div>
-          </main>
-          <footer className="py-32">
-            <ul className="flex flex-col gap-24">
-              <li className="flex flex-col gap-4">
-                <p className="text-body-3-medium text-blue-20">Email</p>
-                <Link
-                  className="text-title-3-regular"
-                  href="mailto:dddstudy1@gmail.com"
-                >
-                  dddstudy1@gmail.com
-                </Link>
-              </li>
-              <li className="flex flex-col gap-4">
-                <p className="text-body-3-medium text-blue-20">Follow Us</p>
-                <ul className="flex gap-8 flex-wrap">
-                  {snsList.map((item) => (
-                    <Link
-                      className="flex gap-4 text-title-3-regular"
-                      href={item.link}
-                      key={item.name}
-                      target="_blank"
-                    >
-                      {item.icon}
-                      <p>{item.name}</p>
-                    </Link>
-                  ))}
-                </ul>
-              </li>
-            </ul>
-          </footer>
-        </div>
-      )}
+      {isMenuOpened && <SideMenu onClose={closeMenu} />}
     </div>
   );
 }

--- a/src/components/Navigation/MobileNavigation.tsx
+++ b/src/components/Navigation/MobileNavigation.tsx
@@ -1,32 +1,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import {
-  DddIcon,
-  MenuIcon,
-  CloseIcon,
-  InstagramIcon,
-  LinkedInIcon,
-  GithubIcon,
-} from "@/components/svgs";
+import { DddIcon, MenuIcon, CloseIcon } from "@/components/svgs";
+import snsList from "@/components/common/snsList";
 import navigationList from "@/fixtures/navigationList.json";
-
-const snsList = [
-  {
-    name: "Instagram",
-    icon: <InstagramIcon />,
-    link: "https://www.instagram.com/dynamic_ddd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
-  },
-  {
-    name: "LinkedIn",
-    icon: <LinkedInIcon />,
-    link: "https://www.linkedin.com/company/dddcommunity",
-  },
-  {
-    name: "Github",
-    icon: <GithubIcon />,
-    link: "https://github.com/DDD-Community",
-  },
-];
 
 export default function MobileNavigation() {
   const [isMenuOpened, setMenuOpened] = useState(false);

--- a/src/components/Navigation/SideMenu.tsx
+++ b/src/components/Navigation/SideMenu.tsx
@@ -27,6 +27,7 @@ export default function SideMenu({ onClose }: Props) {
                 href={item.href}
                 key={item.name}
                 className="text-headline-5-bold font-medium tablet:text-headline-4-semibold tablet:font-medium"
+                onClick={onClose}
               >
                 {item.name}
               </Link>

--- a/src/components/Navigation/SideMenu.tsx
+++ b/src/components/Navigation/SideMenu.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import snsList from "@/components/common/snsList";
+import navigationList from "@/fixtures/navigationList.json";
+import { CloseIcon } from "@/components/svgs";
+import { Portal } from "../Portal";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function SideMenu({ onClose }: Props) {
+  return (
+    <Portal>
+      <div className="px-24 fixed top-0 left-0 w-full h-[100dvh] bg-blue-40 text-white flex flex-col z-10">
+        <header className="pt-24 flex justify-end">
+          <button
+            className="bg-white w-48 h-48 rounded-full flex justify-center items-center flex-shrink-0"
+            onClick={onClose}
+          >
+            <CloseIcon />
+          </button>
+        </header>
+        <main className="flex flex-col justify-center flex-1">
+          <div className="flex flex-col gap-6 tablet:gap-20">
+            {navigationList.map((item) => (
+              <Link
+                href={item.href}
+                key={item.name}
+                className="text-headline-5-bold font-medium tablet:text-headline-4-semibold tablet:font-medium"
+              >
+                {item.name}
+              </Link>
+            ))}
+          </div>
+        </main>
+        <footer className="py-32">
+          <ul className="flex flex-col gap-24">
+            <li className="flex flex-col gap-4">
+              <p className="text-body-3-medium text-blue-20">Email</p>
+              <Link
+                className="text-title-3-regular"
+                href="mailto:dddstudy1@gmail.com"
+              >
+                dddstudy1@gmail.com
+              </Link>
+            </li>
+            <li className="flex flex-col gap-4">
+              <p className="text-body-3-medium text-blue-20">Follow Us</p>
+              <ul className="flex gap-8 flex-wrap">
+                {snsList.map((item) => (
+                  <Link
+                    className="flex gap-4 text-title-3-regular"
+                    href={item.link}
+                    key={item.name}
+                    target="_blank"
+                  >
+                    {item.icon}
+                    <p>{item.name}</p>
+                  </Link>
+                ))}
+              </ul>
+            </li>
+          </ul>
+        </footer>
+      </div>
+    </Portal>
+  );
+}

--- a/src/components/common/snsList.tsx
+++ b/src/components/common/snsList.tsx
@@ -1,0 +1,21 @@
+import { InstagramIcon, LinkedInIcon, GithubIcon } from "@/components/svgs";
+
+const snsList = [
+  {
+    name: "Instagram",
+    icon: <InstagramIcon />,
+    link: "https://www.instagram.com/dynamic_ddd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+  },
+  {
+    name: "LinkedIn",
+    icon: <LinkedInIcon />,
+    link: "https://www.linkedin.com/company/dddcommunity",
+  },
+  {
+    name: "Github",
+    icon: <GithubIcon />,
+    link: "https://github.com/DDD-Community",
+  },
+];
+
+export default snsList;


### PR DESCRIPTION
### 작업 내용
* sns 목록을 공통화해서 푸터와 사이드 메뉴 양쪽에서 재사용 가능하도록 합니다.
* 모바일 사이드 메뉴의 코드를 모바일 네비게이션 컴포넌트에서 분리하고, portal을 사용해서 html 상에서도 분리합니다.
* 이슈 해결
  * 사이드 메뉴에서 링크를 선택했을 때 닫히지 않는 문제
  * 모바일 네비게이션의 백그라운드뿐만 아니라 글자까지 blur되는 문제