### PR TITLE
fix: 사용하지 않는 import 삭제

### DIFF
--- a/src/components/HoverSwitch/index.stories.tsx
+++ b/src/components/HoverSwitch/index.stories.tsx
@@ -1,6 +1,4 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { useArgs } from "@storybook/preview-api";
-
 import HoverSwitch from "./index";
 
 const meta = {

--- a/src/components/Layout/Footer/index.tsx
+++ b/src/components/Layout/Footer/index.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import snsList from "@/components/common/snsList";
-import HoverSwitch from "@/components/HoverSwitch";
 import ApplyButtonWrapper from "./ApplyButtonWrapper";
 
 function LinkList({


### PR DESCRIPTION
### 작업 내용
* 사용하지 않는 import 문이 있어 스토리북 chromatic 배포가 실패합니다. 이를 해결합니다.