### PR TITLE
fix: 아코디언 사이즈를 미디어쿼리로 바꿔, 마운트되기 전에도 화면에 보이도록 개선

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -30,20 +30,6 @@ export default function FAQ() {
   const isTablet = useMediaQuery(screenMediaQuery.netbook);
   const isDesktop = useMediaQuery(screenMediaQuery.desktop);
 
-  const deviceType = useMemo(() => {
-    if (isMobile) return "mobile";
-    if (isTablet) return "tablet";
-    return "desktop";
-  }, [isMobile, isTablet, isDesktop]);
-
-  const [accordionSize, setAccordionSize] = useState<AccordionSize>(deviceType);
-
-  useEffect(() => {
-    setAccordionSize(deviceType);
-  }, [deviceType]);
-
-  if ([isMobile, isTablet, isDesktop].some((val) => val == null)) return null;
-
   return (
     <div className="flex flex-col items-center netbook:px-0">
       <h1 className="pt-[132px] px-20 mb-20 text-headline-4-semibold max-w-[800px] netbook:pt-[248px] netbook:mb-24 netbook:text-headline-1-semibold text-center">
@@ -66,7 +52,7 @@ export default function FAQ() {
           ))}
         </div>
         <div className="pt-48 pb-[200px]">
-          <AccordionGroup list={faqList[questionType]} size={accordionSize} />
+          <AccordionGroup list={faqList[questionType]} />
         </div>
       </main>
     </div>

--- a/src/components/Accordion/index.stories.tsx
+++ b/src/components/Accordion/index.stories.tsx
@@ -17,12 +17,6 @@ const meta = {
     ),
   ],
   argTypes: {
-    size: {
-      control: {
-        type: "select",
-      },
-      options: ["desktop", "tablet", "mobile"],
-    },
     label: {
       control: "text",
     },
@@ -39,73 +33,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
+export const Default: Story = {
   args: {
-    size: "desktop",
-    label: "모집 및 지원",
-    title: "지원 방법이 궁금해요.",
-    description: (
-      <p>
-        지원 방법은 간단해요.
-        <br />
-        <br />
-        모집 기간에 열리는 모집 링크(구글 폼)를 통해 지원해 주세요.
-        <br />
-        필요한 내용은 모집 링크에 다 있어요!
-        <br />
-        <br />
-        <strong>1차 서류</strong> 지원 이후에 <strong>2차 인터뷰</strong>를
-        진행할 분들에게 따로 연락을 드려요.
-      </p>
-    ),
-    isActive: false,
-    onClick: () => {},
-  },
-  render: function Render(args) {
-    const [{ isActive }, updateArgs] = useArgs();
-    function onClick() {
-      updateArgs({ isActive: !isActive });
-    }
-
-    return <Accordion {...args} onClick={onClick} />;
-  },
-};
-
-export const Tablet: Story = {
-  args: {
-    size: "tablet",
-    label: "모집 및 지원",
-    title: "지원 방법이 궁금해요.",
-    description: (
-      <p>
-        지원 방법은 간단해요.
-        <br />
-        <br />
-        모집 기간에 열리는 모집 링크(구글 폼)를 통해 지원해 주세요.
-        <br />
-        필요한 내용은 모집 링크에 다 있어요!
-        <br />
-        <br />
-        <strong>1차 서류</strong> 지원 이후에 <strong>2차 인터뷰</strong>를
-        진행할 분들에게 따로 연락을 드려요.
-      </p>
-    ),
-    isActive: false,
-    onClick: () => {},
-  },
-  render: function Render(args) {
-    const [{ isActive }, updateArgs] = useArgs();
-    function onClick() {
-      updateArgs({ isActive: !isActive });
-    }
-
-    return <Accordion {...args} onClick={onClick} />;
-  },
-};
-
-export const Mobile: Story = {
-  args: {
-    size: "mobile",
     label: "모집 및 지원",
     title: "지원 방법이 궁금해요.",
     description: (

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,71 +1,10 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 import { AddIcon, SubtractIcon } from "@/components/svgs";
 
-const accordionVariants = cva("w-full rounded-[20px] bg-white", {
-  variants: {
-    size: {
-      desktop: "px-64 py-40",
-      tablet: "px-40 py-32",
-      mobile: "p-24",
-    },
-  },
-});
-
-const labelVariants = cva("", {
-  variants: {
-    size: {
-      desktop: "text-body-3-medium mb-8",
-      tablet: "text-body-3-medium mb-8",
-      mobile: "text-body-4-medium mb-4",
-    },
-  },
-});
-
-const titleVariants = cva("", {
-  variants: {
-    size: {
-      desktop: "text-title-2-bold",
-      tablet: "text-title-3-bold",
-      mobile: "text-body-3-bold",
-    },
-  },
-});
-
-const descriptionVariants = cva("text-gray-70", {
-  variants: {
-    size: {
-      desktop: "mt-24 text-body-1-regular",
-      tablet: "mt-20 text-body-2-regular",
-      mobile: "mt-16 text-body-3-regular",
-    },
-  },
-});
-
-const touchAreaVariants = cva("", {
-  variants: {
-    size: {
-      desktop: "pt-14 pl-20",
-      tablet: "pt-14 pl-20",
-      mobile: "pt-12 pl-20",
-    },
-  },
-});
-
-const iconButtonVariants = cva("", {
-  variants: {
-    size: {
-      desktop: "h-40 w-40",
-      tablet: "h-40 w-40",
-      mobile: "h-24 w-24",
-    },
-  },
-});
-
-interface AccordionProps extends VariantProps<typeof accordionVariants> {
+interface AccordionProps {
   label: string;
   title: string;
   description: React.ReactNode;
@@ -75,7 +14,6 @@ interface AccordionProps extends VariantProps<typeof accordionVariants> {
 }
 
 export function Accordion({
-  size = "desktop",
   label,
   title,
   description,
@@ -96,15 +34,25 @@ export function Accordion({
   }, [isActive]);
 
   return (
-    <div className={cn(accordionVariants({ size }), className)}>
+    <div
+      className={cn(
+        "w-full rounded-[20px] bg-white",
+        "p-24 desktop:px-64 desktop:py-40 tablet:px-40 tablet:py-32",
+        className
+      )}
+    >
       <div className="flex justify-between">
         <div className="flex flex-col">
-          <p className={cn(labelVariants({ size }))}>{label}</p>
-          <p className={cn(titleVariants({ size }))}>{title}</p>
+          <p className="text-body-4-medium mb-4 tablet:text-body-3-medium tablet:mb-8">
+            {label}
+          </p>
+          <p className="text-body-3-bold tablet:text-title-3-bold desktop:text-title-2-bold">
+            {title}
+          </p>
         </div>
-        <div className={cn(touchAreaVariants({ size }))}>
+        <div className="pt-12 pl-20 tablet:pt-14">
           <button
-            className={cn(iconButtonVariants({ size }))}
+            className="h-24 w-24 tablet:h-40 tablet:w-40"
             type="button"
             onClick={onClick}
           >
@@ -117,7 +65,9 @@ export function Accordion({
         style={{ height: `${contentHeight}px` }}
         className="overflow-hidden transition-[height] duration-300 ease-in-out"
       >
-        <div className={cn(descriptionVariants({ size }))}>{description}</div>
+        <div className="text-gray-70 mt-16 text-body-3-regular tablet:mt-20 tablet:text-body-2-regular desktop:mt-24 desktop:text-body-1-regular">
+          {description}
+        </div>
       </div>
     </div>
   );
@@ -125,10 +75,9 @@ export function Accordion({
 
 interface AccordionGroupProps {
   list: Array<{ label: string; title: string; description: React.ReactNode }>;
-  size: AccordionProps["size"];
 }
 
-export function AccordionGroup({ list, size = "tablet" }: AccordionGroupProps) {
+export function AccordionGroup({ list }: AccordionGroupProps) {
   const [activeItemIndex, setActiveItemIndex] = useState<number | null>(null);
 
   const handleItemClick = (key: number) => {
@@ -143,7 +92,6 @@ export function AccordionGroup({ list, size = "tablet" }: AccordionGroupProps) {
           label={item.label}
           title={item.title}
           description={item.description}
-          size={size}
           isActive={activeItemIndex === index}
           onClick={() => handleItemClick(index)}
         />


### PR DESCRIPTION
### 작업 내용
* 기존에는 아코디언 사이즈를 prop으로 받아 적용했습니다. `useMediaQuery` 훅을 사용하여 마운트될 때 사이즈가 결정되므로 계산되기 전까지는 null이 렌더링되었습니다.
* 따라서 페이지 진입 혹은 새로고침 시 화면에 아무것도 보이지 않다가 렌더링됩니다.
* 사용성에 문제가 있다고 판단, 아코디언의 사이즈를 css 미디어쿼리를 사용하여 변경하도록 합니다.

### 이미지 혹은 동영상
[개선 전]

https://github.com/user-attachments/assets/4da237be-de4d-49f3-be72-63cf1ed52df2




[개선 후]

https://github.com/user-attachments/assets/1ce9febf-a350-46a9-8308-98050c5777d4

