### PR TITLE
fix: 화면 너비를 변화할 때 아코디언 내 description이 잘리는 문제 해결

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { cn } from "@/utils/cn";
 import { AddIcon, SubtractIcon } from "@/components/svgs";
 
@@ -21,18 +21,6 @@ export function Accordion({
   isActive,
   onClick,
 }: AccordionProps) {
-  const [contentHeight, setContentHeight] = useState(0);
-  const contentRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const contentEl = contentRef.current;
-    if (isActive && contentEl) {
-      setContentHeight(contentEl.scrollHeight);
-    } else {
-      setContentHeight(0);
-    }
-  }, [isActive]);
-
   return (
     <div
       className={cn(
@@ -60,13 +48,19 @@ export function Accordion({
           </button>
         </div>
       </div>
+
       <div
-        ref={contentRef}
-        style={{ height: `${contentHeight}px` }}
-        className="overflow-hidden transition-[height] duration-300 ease-in-out"
+        className={cn(
+          "grid transition-all duration-300 ease-in-out",
+          isActive
+            ? "grid-rows-[1fr] opacity-100 mt-16"
+            : "grid-rows-[0fr] opacity-0 mt-0"
+        )}
       >
-        <div className="text-gray-70 mt-16 text-body-3-regular tablet:mt-20 tablet:text-body-2-regular desktop:mt-24 desktop:text-body-1-regular">
-          {description}
+        <div className="overflow-hidden">
+          <div className="text-gray-70 text-body-3-regular tablet:mt-4 tablet:text-body-2-regular desktop:mt-8 desktop:text-body-1-regular">
+            {description}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 작업 내용
* 동적으로 높이를 계산할 필요 없이 grid를 사용한 transition 적용
* grid-template-rows 0fr로 없애고 1fr로 최대 높이로 자연스럽게 채울 수 있음

### 참고사항
* [참고자료](https://medium.com/likeacoffee-dev/creating-a-dynamic-height-accordion-with-css-grid-38bdb2e3a29b)

### 이미지 혹은 동영상

[개선 전]

https://github.com/user-attachments/assets/2f22576a-b851-4a4b-b69e-4ea911b4b60b


[개선 후]

https://github.com/user-attachments/assets/29815976-89cd-4f2e-a62b-e68aa52d58e4


