### PR TITLE
feat: 아코디언 관련 버그 해결 및 label prop 옵셔널로 변경

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -72,22 +72,22 @@ interface AccordionGroupProps {
 }
 
 export function AccordionGroup({ list }: AccordionGroupProps) {
-  const [activeItemIndex, setActiveItemIndex] = useState<number | null>(null);
+  const [activeItemKey, setActiveItemKey] = useState<string | null>(null);
 
-  const handleItemClick = (key: number) => {
-    setActiveItemIndex((prev) => (prev === key ? null : key));
+  const handleItemClick = (key: string) => {
+    setActiveItemKey((prev) => (prev === key ? null : key));
   };
 
   return (
     <div className="flex flex-col gap-16">
-      {list.map((item, index) => (
+      {list.map((item) => (
         <Accordion
           key={item.title}
           label={item.label}
           title={item.title}
           description={item.description}
-          isActive={activeItemIndex === index}
-          onClick={() => handleItemClick(index)}
+          isActive={activeItemKey === item.title}
+          onClick={() => handleItemClick(item.title)}
         />
       ))}
     </div>

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/utils/cn";
 import { AddIcon, SubtractIcon } from "@/components/svgs";
 
 interface AccordionProps {
-  label: string;
+  label?: string;
   title: string;
   description: React.ReactNode;
   className?: string;
@@ -31,10 +31,12 @@ export function Accordion({
       onClick={onClick}
     >
       <div className="flex justify-between">
-        <div className="flex flex-col">
-          <p className="text-body-4-medium mb-4 tablet:text-body-3-medium tablet:mb-8">
-            {label}
-          </p>
+        <div className="flex flex-col justify-center">
+          {label && (
+            <p className="text-body-4-medium mb-4 tablet:text-body-3-medium tablet:mb-8">
+              {label}
+            </p>
+          )}
           <p className="text-body-3-bold tablet:text-title-3-bold desktop:text-title-2-bold">
             {title}
           </p>

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -24,10 +24,11 @@ export function Accordion({
   return (
     <div
       className={cn(
-        "w-full rounded-[20px] bg-white",
+        "w-full rounded-[20px] bg-white cursor-pointer",
         "p-24 desktop:px-64 desktop:py-40 tablet:px-40 tablet:py-32",
         className
       )}
+      onClick={onClick}
     >
       <div className="flex justify-between">
         <div className="flex flex-col">
@@ -39,11 +40,7 @@ export function Accordion({
           </p>
         </div>
         <div className="pt-12 pl-20 tablet:pt-14">
-          <button
-            className="h-24 w-24 tablet:h-40 tablet:w-40"
-            type="button"
-            onClick={onClick}
-          >
+          <button className="h-24 w-24 tablet:h-40 tablet:w-40" type="button">
             {isActive ? <SubtractIcon /> : <AddIcon />}
           </button>
         </div>

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -24,13 +24,13 @@ export function Accordion({
   return (
     <div
       className={cn(
-        "w-full rounded-[20px] bg-white cursor-pointer",
+        "w-full rounded-[20px] bg-white",
         "p-24 desktop:px-64 desktop:py-40 tablet:px-40 tablet:py-32",
         className
       )}
-      onClick={onClick}
+      
     >
-      <div className="flex justify-between">
+      <button className="flex justify-between w-full text-start" onClick={onClick}>
         <div className="flex flex-col justify-center">
           {label && (
             <p className="text-body-4-medium mb-4 tablet:text-body-3-medium tablet:mb-8">
@@ -42,11 +42,11 @@ export function Accordion({
           </p>
         </div>
         <div className="pt-12 pl-20 tablet:pt-14">
-          <button className="h-24 w-24 tablet:h-40 tablet:w-40" type="button">
+          <div className="h-24 w-24 tablet:h-40 tablet:w-40">
             {isActive ? <SubtractIcon /> : <AddIcon />}
-          </button>
+          </div>
         </div>
-      </div>
+      </button>
 
       <div
         className={cn(


### PR DESCRIPTION
### 작업 내용
* [아코디언 중 하나를 연 상태에서 리스트를 교체할 때 해당 인덱스의 아코디언이 이미 열려 있는 문제 해결](https://github.com/dddstudy/ddd-web/commit/34f99c53c2bbd4f6a5eb2c44358b8791015ffe0b)
  * 예를 들어 - 첫 번째 탭의 두 번째 아코디언이 열려 있음 > 두 번째 탭으로 옮김 > 두 번째 탭의 두 번째 아코디언이 열려 있음
  * AccordionGroup에서 열려 있는 아코디언을 index를 사용하여 판단하고 있기 때문입니다. index 대신 title을 key로 사용합니다.
* 모바일에서 아코디언 버튼이 작아 열고 닫기 불편한 점이 있습니다. 아코디언 자체를 클릭하여 여닫을 수 있도록 합니다.
* 12기 모집 페이지의 아코디언은 label이 없으므로, label prop을 옵셔널로 변경합니다.